### PR TITLE
refactor(cli): use Changed() API for --duration flag instead of -1 se…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ drift uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **CLI**: `--duration` flag now uses cobra's `Changed()` API instead of a `-1` sentinel to detect explicit user input; flag default changed from `-1` to `0`
+
 ---
 
 ## [0.3.0] — 2026-03-20

--- a/cmd/drift/root.go
+++ b/cmd/drift/root.go
@@ -66,7 +66,7 @@ func init() {
 	f.StringVarP(&flagTheme, "theme", "t", "", "color theme (overrides config)")
 	f.StringVarP(&flagScene, "scene", "s", "", "lock to a specific scene (overrides config)")
 	f.IntVar(&flagFPS, "fps", 0, "target frame rate in Hz (overrides config)")
-	f.Float64Var(&flagDuration, "duration", -1, "seconds per scene when cycling, 0 = no cycling (overrides config)")
+	f.Float64Var(&flagDuration, "duration", 0, "seconds per scene when cycling, 0 = no cycling (overrides config)")
 
 	rootCmd.AddCommand(shellInitCmd)
 	rootCmd.AddCommand(listCmd)
@@ -92,7 +92,7 @@ func runEngine(cmd *cobra.Command, _ []string) error {
 	if flagFPS > 0 {
 		cfg.Engine.FPS = flagFPS
 	}
-	if flagDuration >= 0 {
+	if cmd.Flags().Changed("duration") {
 		cfg.Engine.CycleSeconds = flagDuration
 	}
 


### PR DESCRIPTION
…ntinel

## What does this PR do?

<!-- one-paragraph summary -->

## Type of change

- [ ] Bug fix
- [ ] New scene
- [ ] New theme
- [ ] Configuration / CLI change
- [ ] Documentation
- [ ] Other

## Testing

- [ ] `make test` passes
- [ ] Tested visually: `drift --scene <name> --theme <name>`

## Screenshots / recording *(for visual changes)*
