### PR TITLE
fix: load config when XDG_CONFIG_HOME uses ~

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -133,7 +134,18 @@ func Path() (string, error) {
 			return "", err
 		}
 		base = filepath.Join(home, ".config")
+	} else if strings.HasPrefix(base, "~/") || base == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if base == "~" {
+			base = home
+		} else {
+			base = filepath.Join(home, strings.TrimPrefix(base, "~/"))
+		}
 	}
+
 	return filepath.Join(base, "drift", "config.toml"), nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -36,6 +38,38 @@ func TestLoadReturnsDefaultsWhenNoFile(t *testing.T) {
 	}
 }
 
+func TestLoadReadsConfigWhenXDGConfigHomeUsesTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "~/.config")
+
+	cfgPath := filepath.Join(home, ".config", "drift", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(cfgPath, []byte(`[engine]
+fps = 60
+
+[scene.waveform]
+layers = 1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Engine.FPS != 60 {
+		t.Fatalf("expected FPS=60, got %d", cfg.Engine.FPS)
+	}
+	if cfg.Scene.Waveform.Layers != 1 {
+		t.Fatalf("expected waveform.layers=1, got %d", cfg.Scene.Waveform.Layers)
+	}
+}
+
 func TestPathUsesXDGConfigHome(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/tmp/testxdg")
 
@@ -45,5 +79,20 @@ func TestPathUsesXDGConfigHome(t *testing.T) {
 	}
 	if p != "/tmp/testxdg/drift/config.toml" {
 		t.Errorf("unexpected path: %s", p)
+	}
+}
+
+func TestPathExpandsTildeInXDGConfigHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "~/.config")
+
+	p, err := Path()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := home + "/.config/drift/config.toml"
+	if p != want {
+		t.Errorf("unexpected path: %s (want %s)", p, want)
 	}
 }


### PR DESCRIPTION
## Bug
if `XDG_CONFIG_HOME` is set to a tilde path (for example `~/.config`), drift would treat it as a literal directory instead of expanding `~`, so the config file at `~/.config/drift/config.toml` was never found and defaults were always used.

## Fix
- Expand `~` / `~/...` in `XDG_CONFIG_HOME` to the current user's home directory before building the config path.
- Added regression tests to ensure both `Path()` and `Load()` work correctly when `XDG_CONFIG_HOME` uses `~`.

## Testing
- `go test ./...`

Happy to address any feedback.

Greetings, saschabuehrle
