### PR TITLE
feat(theme): add rosepine theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ drift ships seven animations. They cycle automatically or you can lock to one.
 
 ## Themes
 
-Eight built-in themes matched to popular terminal colorschemes.
+Nine built-in themes matched to popular terminal colorschemes.
 
-`cosmic` · `nord` · `dracula` · `catppuccin` · `gruvbox` · `forest` · `wildberries` · `mono`
+`cosmic` · `nord` · `dracula` · `catppuccin` · `gruvbox` · `forest` · `wildberries` · `mono` · `rosepine`
+
 
 ```bash
 drift list themes    # preview all themes with color swatches

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,7 +222,7 @@ timeout = 120
 fps           = 30     # target frames per second
 cycle_seconds = 60     # seconds per scene, 0 = stay on one scene
 scenes        = "all"  # comma-separated list or "all"
-theme         = "cosmic" # cosmic | nord | dracula | catppuccin | gruvbox | forest | wildberries | mono
+theme         = "cosmic" # cosmic | nord | dracula | catppuccin | gruvbox | forest | wildberries | mono | rosepine
 shuffle       = true   # randomise scene order
 
 [scene.constellation]

--- a/internal/scene/scene.go
+++ b/internal/scene/scene.go
@@ -233,6 +233,22 @@ var Themes = map[string]Theme{
 		},
 		Bright: RGBColor{180, 255, 200},
 	},
+	"rosepine": {
+		Name: "rosepine",
+		Palette: []RGBColor{
+			{235, 111, 146},
+			{196, 167, 231},
+			{156, 207, 216},
+			{49, 116, 143},
+		},
+		Dim: []RGBColor{
+			{25, 23, 36},
+			{31, 29, 46},
+			{38, 35, 58},
+			{28, 26, 42},
+		},
+		Bright: RGBColor{224, 222, 244},
+	},
 }
 
 func ThemeNames() []string {


### PR DESCRIPTION
## What does this PR do?

Adds Rosé Pine theme.

## Type of change

- [ ] Bug fix
- [ ] New scene
- [x] New theme
- [ ] Configuration / CLI change
- [ ] Documentation
- [ ] Other

## Testing

- [x] `make test` passes
- [x] Tested visually: `drift --scene <name> --theme <name>`

## Screenshots / recording *(for visual changes)*
<img width="2560" height="1440" alt="screenshot-1774121790" src="https://github.com/user-attachments/assets/66773824-5ec7-453f-a751-7879481a3fb3" />
