### PR TITLE
Feat/tmux status toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ drift uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.6.0] — 2026-03-21
 
 ### Added
+- tmux status bar toggle feature. When enabled, drift will automatically hide the tmux status bar when a scene is active and restore it when exiting. This is configurable via `[engine]` section in `config.toml` with `hide_tmux_status = true|false` (default: false).
 
 - **rosepine** theme — Rosé Pine colorscheme; palette uses Love, Iris, Foam, and Pine accents with the base background layers as dim variants
 - **automatic PR labeling** — labels applied automatically on PRs based on changed file paths and branch name prefix via `actions/labeler`

--- a/README.md
+++ b/README.md
@@ -216,11 +216,12 @@ drift config --init   # writes ~/.config/drift/config.toml
 
 ```toml
 [engine]
-fps           = 30
-cycle_seconds = 60    # 0 = stay on one scene
-scenes        = "all"
-theme         = "cosmic"
-shuffle       = true
+fps              = 30
+cycle_seconds    = 60    # 0 = stay on one scene
+scenes           = "all"
+theme            = "cosmic"
+shuffle          = true
+hide_tmux_status = false
 
 [scene.constellation]
 star_count      = 80

--- a/cmd/drift/root.go
+++ b/cmd/drift/root.go
@@ -205,6 +205,7 @@ func showConfig() error {
 	fmt.Printf("cycle_seconds: %.0f\n", cfg.Engine.CycleSeconds)
 	fmt.Printf("scenes:        %s\n", cfg.Engine.Scenes)
 	fmt.Printf("shuffle:       %v\n", cfg.Engine.Shuffle)
+	fmt.Printf("hide_tmux_status: %v\n", cfg.Engine.HideTmuxStatus)
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,8 @@ type EngineConfig struct {
 	Scenes  string `toml:"scenes"`
 	Theme   string `toml:"theme"`
 	Shuffle bool   `toml:"shuffle"`
+	// runs `tmux set status off` while drift runs when inside tmux.
+	HideTmuxStatus bool `toml:"hide_tmux_status"`
 }
 
 type SceneConfig struct {
@@ -224,6 +226,7 @@ cycle_seconds = 60     # seconds per scene, 0 = stay on one scene
 scenes        = "all"  # comma-separated list or "all"
 theme         = "cosmic" # cosmic | nord | dracula | catppuccin | gruvbox | forest | wildberries | mono | rosepine
 shuffle       = true   # randomise scene order
+hide_tmux_status = false  # tmux: hide status bar while displaying scene
 
 [scene.constellation]
 star_count      = 80

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -4,6 +4,8 @@ package engine
 import (
 	"fmt"
 	"math/rand"
+	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -48,6 +50,12 @@ func New(cfg config.Config) *Engine {
 // Run initialises the terminal and blocks until a keypress or click.
 // The terminal is fully restored on return regardless of how Run exits.
 func (e *Engine) Run() error {
+	if e.cfg.Engine.HideTmuxStatus && os.Getenv("TMUX") != "" {
+		if err := exec.Command("tmux", "set", "status", "off").Run(); err == nil {
+			defer func() { _ = exec.Command("tmux", "set", "status", "on").Run() }()
+		}
+	}
+
 	screen, err := tcell.NewScreen()
 	if err != nil {
 		return fmt.Errorf("create screen: %w", err)


### PR DESCRIPTION
## Summary

Ability to toggle tmux status bar. Default set to off. Since tmux is widely used i believe this will be useful config.
Feature inspired by [folke](https://github.com/folke)'s [zen-mode.nvim](https://github.com/folke/zen-mode.nvim/commit/67df395fc10af373dca6326ee22b939d5f2f6647) plugin.

## Type of change

- [ ] Bug fix
- [ ] New scene
- [ ] New theme
- [ ] Configuration / CLI change
- [ ] Documentation
- [x] Other

## Checklist

- [x] Branch name follows `<type>/<short-description>` convention (e.g. `feat/aurora-scene`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] `make test` passes
- [x] `go vet ./...` passes

**For new scenes:**
- [ ] Implements the full `Scene` interface (`Name`, `Init`, `Update`, `Draw`, `Resize`)
- [ ] Uses `dt` for all time-based motion — no frame-counting
- [ ] Respects the theme — uses `t.Palette`, `t.Dim`, `t.Bright`; no hardcoded colors
- [ ] Never calls `screen.Show()` inside `Draw`
- [ ] Added config struct to `config.go` with sensible defaults
- [ ] Tested visually across at least two themes
- [ ] Demo GIF added to `demo/`

**For new themes:**
- [ ] Added to `Themes` map in `internal/scene/scene.go`
- [ ] Theme name added to comment in `internal/config/config.go`
- [ ] README theme list updated
- [ ] Tested visually with at least two scenes

## Screenshots / recording *(required for new scenes and themes)*

![output](https://github.com/user-attachments/assets/b934ec08-6766-47ca-9fd2-6e487213d0e4)

