### PR TITLE
fix(scene): use time-varying seed for orrery RNG on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ drift uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **orrery** scene — terminal resize no longer resets the RNG to the same seed used at init, preventing repetitive asteroid and UFO spawn patterns after resize events
+
 ---
 
 ## [0.10.0] — 2026-03-29

--- a/internal/scene/orrery/orrery.go
+++ b/internal/scene/orrery/orrery.go
@@ -114,7 +114,7 @@ func (o *Orrery) Resize(w, h int) {
 
 	o.w, o.h = w, h
 	o.pw, o.ph = w*2, h*4
-	o.rng = rand.New(rand.NewSource(int64(w)*91841 ^ int64(h)*69457 ^ 0x77a31))
+	o.rng = rand.New(rand.NewSource(int64(w)*91841 ^ int64(h)*69457 ^ 0x77a31 ^ int64(o.time*1000)))
 	o.centerX = float64(max(o.pw-1, 0)) / 2
 	o.centerY = float64(max(o.ph-1, 0)) / 2
 	o.allocBuffers()


### PR DESCRIPTION
## Summary

Fixes #36

- Incorporates elapsed scene time into the RNG seed during `Resize()`, preventing identical random sequences after terminal resize
- `Init()` remains deterministic (time=0 on first init)
- Single-line change in `internal/scene/orrery.go`

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing orrery tests pass)
- [ ] Visual verification: run `drift --scene orrery`, resize terminal multiple times — asteroid/UFO spawn positions should vary