### PR TITLE
refactor: extract magic numbers into named constants

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -15,6 +15,10 @@ import (
 	"github.com/phlx0/drift/internal/scene"
 )
 
+// maxDeltaTime caps the per-frame time step to prevent large jumps
+// after sleep/wake or scheduler stalls.
+const maxDeltaTime = 0.1
+
 // shiftScreen wraps tcell.Screen and translates every SetContent call by
 // (ox, oy), discarding writes that land outside the physical screen bounds.
 // All other Screen methods delegate to the underlying screen unchanged.
@@ -285,9 +289,8 @@ func (e *Engine) drawHUD(screen tcell.Screen, w, h int) {
 
 // handleTick advances the simulation by dt seconds and redraws the screen.
 func (e *Engine) handleTick(dt float64, screen tcell.Screen, w, h *int) {
-	// Cap dt to prevent large jumps after sleep/wake.
-	if dt > 0.1 {
-		dt = 0.1
+	if dt > maxDeltaTime {
+		dt = maxDeltaTime
 	}
 
 	// Advance OLED pixel shift: nudge by 1 cell every 10 seconds,

--- a/internal/scene/orrery.go
+++ b/internal/scene/orrery.go
@@ -18,6 +18,11 @@ const (
 
 	orrerySunExclusionRadius = 8.4
 	orreryAsteroidClearance  = 0.15
+
+	// Hash multipliers for the deterministic RNG seed.
+	orreryRNGSeedMulW int64 = 91841
+	orreryRNGSeedMulH int64 = 69457
+	orreryRNGSeedBase int64 = 0x77a31
 )
 
 type Orrery struct {
@@ -97,7 +102,7 @@ func (o *Orrery) Init(w, h int, t Theme) {
 	o.pw, o.ph = w*2, h*4
 	o.theme = t
 	o.time = 0
-	o.rng = rand.New(rand.NewSource(int64(w)*91841 ^ int64(h)*69457 ^ 0x77a31))
+	o.rng = rand.New(rand.NewSource(int64(w)*orreryRNGSeedMulW ^ int64(h)*orreryRNGSeedMulH ^ orreryRNGSeedBase))
 	o.centerX = float64(max(o.pw-1, 0)) / 2
 	o.centerY = float64(max(o.ph-1, 0)) / 2
 	o.allocBuffers()
@@ -114,7 +119,7 @@ func (o *Orrery) Resize(w, h int) {
 
 	o.w, o.h = w, h
 	o.pw, o.ph = w*2, h*4
-	o.rng = rand.New(rand.NewSource(int64(w)*91841 ^ int64(h)*69457 ^ 0x77a31))
+	o.rng = rand.New(rand.NewSource(int64(w)*orreryRNGSeedMulW ^ int64(h)*orreryRNGSeedMulH ^ orreryRNGSeedBase))
 	o.centerX = float64(max(o.pw-1, 0)) / 2
 	o.centerY = float64(max(o.ph-1, 0)) / 2
 	o.allocBuffers()

--- a/internal/scene/particles.go
+++ b/internal/scene/particles.go
@@ -9,6 +9,8 @@ import (
 	"github.com/phlx0/drift/internal/config"
 )
 
+const particleTrailDecayRate = 2.8 // brightness units per second
+
 var particleGlyphs = []rune{'◦', '·', '○', '•', '.', '°', '∘'}
 
 type Particles struct {
@@ -120,7 +122,7 @@ func flowField(x, y, t float64) (fx, fy float64) {
 func (p *Particles) Update(dt float64) {
 	p.time += dt
 
-	decay := dt * 2.8
+	decay := dt * particleTrailDecayRate
 	for x := range p.trail {
 		for y := range p.trail[x] {
 			if v := p.trail[x][y] - decay; v > 0 {

--- a/internal/scene/waveform.go
+++ b/internal/scene/waveform.go
@@ -7,6 +7,10 @@ import (
 	"github.com/phlx0/drift/internal/config"
 )
 
+// waveformAmplitudeScale converts configured amplitude to pixel height.
+// At the default amplitude of 0.70 this yields ~22% of pixel height.
+const waveformAmplitudeScale = 0.31
+
 // brailleOffsets maps (row, col) inside a braille cell to its Unicode bit offset.
 //
 // Unicode braille bit layout (U+2800 base):
@@ -74,7 +78,7 @@ func (wf *Waveform) Init(w, h int, t Theme) {
 // Called from Init and Resize so both paths stay in sync.
 func (wf *Waveform) buildLayers() {
 	// amplitude * 0.31 gives ~22% of pixel height at the default value of 0.70.
-	baseAmp := float64(wf.ph) * wf.cfgAmplitude * 0.31
+	baseAmp := float64(wf.ph) * wf.cfgAmplitude * waveformAmplitudeScale
 
 	numLayers := wf.cfgLayers
 	if numLayers < 1 {


### PR DESCRIPTION
## Summary

Closes #38

Replaces hardcoded numeric literals with descriptive named constants across four files:

- `waveformAmplitudeScale` (0.31) in `waveform.go`
- `particleTrailDecayRate` (2.8) in `particles.go`
- `maxDeltaTime` (0.1) in `engine.go`
- `orreryRNGSeedMulW/MulH/Base` in `orrery.go`

No behavioral change — purely a readability improvement.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] No logic changes, only constant extraction